### PR TITLE
fix list_available_erl_versions, wget all the way down

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,6 @@ If that executes fine, then you'll should have a list of actions you can execute
 
 This script is dependent on :
 
-- *lynx* (<http://lynx.isc.org/>)
 - *wget*
 
 ## Erlang dependencies

--- a/evm
+++ b/evm
@@ -4,7 +4,6 @@
 # Read the page http://www.erlang.org/download.html and catch
 # all available erlang versions to download
 #
-# Dependencies: lynx
 #  Added support to new versioning of erlang "OTP ..." instead of "R..."
 #
 

--- a/evm
+++ b/evm
@@ -27,9 +27,10 @@ function strip_version() {
 }
 
 function list_available_erl_versions() {
-  lynx -dump -nolist "$ERLANG_ORG" "$AUTH" \
-      | \grep -E "\* (R|OTP\s*)[1-9]+" \
-      | sed 's/.*\* //' | sed 's/ /_/'  
+  curl "$ERLANG_ORG" \
+     | sed '1,/Available releases/'d \
+     | grep -E "^\s*(R|OTP\s*)[1-9]+" \
+     | sed 's/^\s*//' | sed 's/ /_/'
 }
 
 # TODO: add here some way to discover what's the 

--- a/evm
+++ b/evm
@@ -27,7 +27,7 @@ function strip_version() {
 }
 
 function list_available_erl_versions() {
-  curl "$ERLANG_ORG" \
+  wget -q -O - "$ERLANG_ORG" \
      | sed '1,/Available releases/'d \
      | grep -E "^\s*(R|OTP\s*)[1-9]+" \
      | sed 's/^\s*//' | sed 's/ /_/'

--- a/evm
+++ b/evm
@@ -53,13 +53,6 @@ function _load() {
 # available erlang versions from erlang.org page
 # @params: none
 function evm_list() {
-  if [[ ! -z "$http_proxy" ]] ## http_proxy is set
-  then
-    local USER=$(echo "$http_proxy" | sed 's|http://||' | cut -d @ -f 1 | cut -d : -f 1)
-    local PASS=$(echo "$http_proxy" | sed 's|http://||' | cut -d @ -f 1 | cut -d : -f 2)
-    local AUTH="-pauth=$USER:$PASS"
-  fi
-
   local ERLANGS="$(list_available_erl_versions)"
   echo Available Erlang versions on $ERLANG_URL
   echo
@@ -77,13 +70,6 @@ function evm_list() {
 # to user
 # @params: erlang_version
 function evm_download() {
-  if [[ ! -z "$http_proxy" ]] ## http_proxy is set
-  then
-    local USER="$(echo "$http_proxy" | sed 's|http://||' | cut -d @ -f 1 | cut -d : -f 1)"
-    local PASS="$(echo "$http_proxy" | sed 's|http://||' | cut -d @ -f 1 | cut -d : -f 2)"
-    local AUTH="-pauth=$USER:$PASS"
-  fi
-
   local ERLANGS="$(list_available_erl_versions)"
   
   if [[ -z $(echo "$ERLANGS" | grep -E "$1") ]]
@@ -133,13 +119,6 @@ function evm_install() {
   then
     echo "$1 is already cached, don't need to download it"
   else
-    if [[ ! -z "$http_proxy" ]] ## http_proxy is set
-    then
-      local USER="$(echo "$http_proxy" | sed 's|http://||' | cut -d @ -f 1 | cut -d : -f 1)"
-      local PASS="$(echo "$http_proxy" | sed 's|http://||' | cut -d @ -f 1 | cut -d : -f 2)"
-      local AUTH="-pauth=$USER:$PASS"
-    fi
-
     local ERLANGS="$(list_available_erl_versions)"
 
     if [[ -z $(echo "$ERLANGS" | grep "$1") ]]

--- a/evm
+++ b/evm
@@ -27,6 +27,11 @@ function strip_version() {
 }
 
 function list_available_erl_versions() {
+  # get the download.html page in a txt format
+  # filter for all lines, below the one containing
+  # "Available releases", containing what looks like
+  # a version string. Strip leading whitespace
+  # and transform remaining spaces to underscores.
   wget -q -O - "$ERLANG_ORG" \
      | sed '1,/Available releases/'d \
      | grep -E "^\s*(R|OTP\s*)[1-9]+" \
@@ -49,9 +54,6 @@ function _load() {
 # available erlang versions from erlang.org page
 # @params: none
 function evm_list() {
-  # get the download.html page in a txt format
-  # filter for all lines in the format '* Rnn' and 
-  # remove all spaces in the beginner of the line
   if [[ ! -z "$http_proxy" ]] ## http_proxy is set
   then
     local USER=$(echo "$http_proxy" | sed 's|http://||' | cut -d @ -f 1 | cut -d : -f 1)

--- a/install
+++ b/install
@@ -6,15 +6,15 @@
 EVM_HOME="$HOME/.evm"
 DIRS="erlang_tars erlang_versions evm_config scripts"
 
-type lynx > /dev/null 2> /dev/null
+type wget > /dev/null 2> /dev/null
 if [[ $? -eq "1" ]]; then
    echo "Could not complete installation of evm."
-   echo "Please install lynx."
+   echo "Please install wget."
    exit 1
 else
-   echo "Lynx found!"
+   echo "wget found!"
 fi
- 
+
 # For each dir, check whether it's already exists or not
 for dir in $DIRS
 do


### PR DESCRIPTION
I wanted to get rid of the dependency to lynx by replacing it with something more common.
Obviously, doc fixes are still pending, also $AUTH is not supported. I can figure that out.

It looks like parsing the site has been broken before, so I did my best to fix that as well.