### PR TITLE
Setting EMV_PS_SHELL based on the valued in $SHELL variable

### DIFF
--- a/evm
+++ b/evm
@@ -5,7 +5,12 @@
 # all available erlang versions to download, including minor releases
 #
 # set -ex
-EVM_PS_SHELL="$(ps | grep $$)"
+if [[ -z "${SHELL}" ]]; then
+  EVM_PS_SHELL="$(ps | grep $$)"
+else
+  EVM_PS_SHELL="$SHELL"
+fi
+
 VERSION="5.0.1"
 ERLANG_ORG="http://www.erlang.org/download/"
 ERLANG_URL="https://github.com"


### PR DESCRIPTION
Relying on `$(ps | grep $$)` to figure out which shell is being used breaks on mac. If $SHELL variable is set, we should believe it. We can fallback to the ps|grep if that is not the case.